### PR TITLE
drop deprecated labels

### DIFF
--- a/searcher.go
+++ b/searcher.go
@@ -69,7 +69,7 @@ func (s *Searcher) SearchCluster(clusterID string) (Cluster, error) {
 func (s *Searcher) search(randomKey *RandomKey, clusterID string, key Key) error {
 	// Select only secrets that match the given key and the given
 	// cluster clusterID.
-	selector := fmt.Sprintf("%s=%s, %s=%s", legacyRandomKeyLabel, key, legacyClusterIDLabel, clusterID)
+	selector := fmt.Sprintf("%s=%s, %s=%s", randomKeyLabel, key, clusterLabel, clusterID)
 
 	watcher, err := s.k8sClient.Core().Secrets(SecretNamespace).Watch(metav1.ListOptions{
 		LabelSelector: selector,
@@ -113,11 +113,11 @@ func fillRandomKeyFromSecret(randomkey *RandomKey, obj runtime.Object, clusterID
 		return microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", secret, obj)
 	}
 
-	gotClusterID := secret.Labels[legacyClusterIDLabel]
+	gotClusterID := secret.Labels[clusterLabel]
 	if clusterID != gotClusterID {
 		return microerror.Maskf(invalidSecretError, "expected clusterID = %q, got %q", clusterID, gotClusterID)
 	}
-	gotKeys := secret.Labels[legacyRandomKeyLabel]
+	gotKeys := secret.Labels[randomKeyLabel]
 	if string(key) != gotKeys {
 		return microerror.Maskf(invalidSecretError, "expected random key = %q, got %q", key, gotKeys)
 	}

--- a/searcher_test.go
+++ b/searcher_test.go
@@ -25,8 +25,8 @@ func Test_fillRandomKeyFromSecret(t *testing.T) {
 			Secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"clusterID":  "eggs2",
-						"clusterKey": "encryption",
+						clusterLabel:   "eggs2",
+						randomKeyLabel: "encryption",
 					},
 				},
 				Data: map[string][]byte{
@@ -45,8 +45,8 @@ func Test_fillRandomKeyFromSecret(t *testing.T) {
 			Secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"clusterID":  "eggs2",
-						"clusterKey": "encryption",
+						clusterLabel:   "eggs2",
+						randomKeyLabel: "encryption",
 					},
 				},
 				Data: map[string][]byte{
@@ -63,8 +63,8 @@ func Test_fillRandomKeyFromSecret(t *testing.T) {
 			Secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"clusterID":  "eggs2",
-						"clusterKey": "encryption",
+						clusterLabel:   "eggs2",
+						randomKeyLabel: "encryption",
 					},
 				},
 				Data: map[string][]byte{
@@ -81,8 +81,8 @@ func Test_fillRandomKeyFromSecret(t *testing.T) {
 			Secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"clusterID":  "eggs2",
-						"clusterKey": "encryption",
+						clusterLabel:   "eggs2",
+						randomKeyLabel: "encryption",
 					},
 				},
 				Data: map[string][]byte{},

--- a/types.go
+++ b/types.go
@@ -2,6 +2,10 @@ package randomkeys
 
 import "fmt"
 
+const (
+	SecretNamespace = "default"
+)
+
 // These constants are used when filtering the secrets, to only retrieve the
 // ones we are interested in.
 const (
@@ -11,19 +15,6 @@ const (
 	// clusterLabel is the label used in the secret to identify a secret
 	// containing the random key.
 	clusterLabel = "giantswarm.io/cluster"
-
-	// legacyRandomKeyLabel is the label used in the secret to identify a secret
-	// containing the random key.
-	//
-	// TODO replace with "giantswarm.io/randomkey".
-	legacyRandomKeyLabel = "clusterKey"
-	// legacyClusterIDLabel is the label used in the secret to identify a secret
-	// containing the random key.
-	//
-	// TODO replace with "giantswarm.io/cluster-id".
-	legacyClusterIDLabel = "clusterID"
-
-	SecretNamespace = "default"
 )
 
 type Key string
@@ -56,9 +47,7 @@ func K8sName(clusterID string, key Key) string {
 // and the key.
 func K8sLabels(clusterID string, key Key) map[string]string {
 	return map[string]string{
-		randomKeyLabel:       key.String(),
-		clusterLabel:         clusterID,
-		legacyRandomKeyLabel: key.String(),
-		legacyClusterIDLabel: clusterID,
+		randomKeyLabel: key.String(),
+		clusterLabel:   clusterID,
 	}
 }


### PR DESCRIPTION
With the recent changes in the Node Pools story we went without the legacy labels in some resource implementations in `cluster-operator`. This is now breaking cluster creation because the random key searcher only looks for deprecated labels. I checked all resource versions in `cluster-operator` and saw that all of them use the new labels. So I consider this safe to be rolled out and fix cluster creation. 